### PR TITLE
Add autoconf-archive to conda create

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@ Build and install
 
 Get the necessary build tools: autotools, git, python=3, gitpython, etc. As a conda environment, this could be:
 
-    conda create -n casm_v2 --override-channels -c conda-forge python=3 m4>=1.4.18 autoconf automake make libtool pkg-config ccache wget bzip2 six git gitpython
+    conda create -n casm_v2 --override-channels -c conda-forge python=3 m4>=1.4.18 autoconf autoconf-archive automake make libtool pkg-config ccache wget bzip2 six git gitpython
     conda activate casm_v2
 
 Clone the repository:


### PR DESCRIPTION
Otherwise I got the error

configure.ac:24: error: possibly undefined macro: AC_MSG_ERROR
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
